### PR TITLE
Add some large positive and negative values to the tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,13 @@
 {
     "cSpell.words": [
+        "cmake",
+        "exitcode",
         "gtest",
         "ints",
         "lgtest",
+        "libgtest",
         "mergesort",
-        "pthread"
+        "pthread",
+        "valgrind"
     ]
 }

--- a/array_merge/array_merge_test.cpp
+++ b/array_merge/array_merge_test.cpp
@@ -59,11 +59,11 @@ TEST(ArrayMerge, Handle_multiple_copies_of_longer_list) {
 TEST(ArrayMerge, Handle_multiple_copies_of_longer_list_different_orders) {
   int num_arrays = 9;
   int sizes[] = { 10, 10, 10, 10, 10, 10, 10, 10, 10 };
-  int a0[] = { 3, 2, 0, 5, 8, 9, 6, 3, 2, 0 };
-  int a1[] = { 5, 8, 9, 3, 2, 0, 6, 3, 2, 0 };
-  int a2[] = { 8, 5, 0, 2, 3, 0, 2, 3, 6, 9 };
+  int a0[] = { 3, -22345, 0, 5, 8, 9, 6, 3, 2, 0 };
+  int a1[] = { 5, 8, 9, 3, 2, 0, 6, 378293, 2, 0 };
+  int a2[] = { 8, -52857, 0, 2, 3, 0, 2, 3, 6, 9 };
   int* a[] = { a0, a1, a2, a0, a1, a2, a0, a1, a2 };
-  int expected[] = { 7, 0, 2, 3, 5, 6, 8, 9 };
+  int expected[] = { 7, -52857, -22345, 0, 2, 3, 5, 6, 8, 9, 378293 };
   int* result;
 
   result = array_merge(num_arrays, sizes, a);


### PR DESCRIPTION
This adds some large numbers to at least one of the test cases in an effort to make it less likely that folks will use bucket sort of find the unique values.

An even better solution would be to generate some *random* numbers. Then there would be no way they could know what values to hack in. Unfortunately that complicates checking that the answer is correct, and almost requires including a solution in the test code (which wouldn't be good).

Closes #5 