### PR TITLE
Fix problem with `mergesort` declaration

### DIFF
--- a/mergesort/mergesort.c
+++ b/mergesort/mergesort.c
@@ -1,7 +1,12 @@
 #include "mergesort.h"
 
-void mergesort(int, int*) {
+void mergesort(int size, int values[]) {
   // This obviously doesn't actually do any *sorting*, so there's
   // certainly work still to be done.
+  //
+  // Remember that a key goal here is to learn to use
+  // `malloc/calloc` and `free`, so make sure you explicitly
+  // allocate any new arrays that you need, even if you
+  // might not strictly need to.
   return;
 }


### PR DESCRIPTION
For some reason we don't have variable names for either of the arguments to `mergesort`, and this should fix that.

I also added a small comment reminding people to use `malloc/calloc` here, even if it's not strictly necessary.