### PR TITLE
Fix bug in array-merge test

### DIFF
--- a/array_merge/array_merge_test.cpp
+++ b/array_merge/array_merge_test.cpp
@@ -63,7 +63,7 @@ TEST(ArrayMerge, Handle_multiple_copies_of_longer_list_different_orders) {
   int a1[] = { 5, 8, 9, 3, 2, 0, 6, 378293, 2, 0 };
   int a2[] = { 8, -52857, 0, 2, 3, 0, 2, 3, 6, 9 };
   int* a[] = { a0, a1, a2, a0, a1, a2, a0, a1, a2 };
-  int expected[] = { 7, -52857, -22345, 0, 2, 3, 5, 6, 8, 9, 378293 };
+  int expected[] = { 10, -52857, -22345, 0, 2, 3, 5, 6, 8, 9, 378293 };
   int* result;
 
   result = array_merge(num_arrays, sizes, a);


### PR DESCRIPTION
When I created the new `Handle_multiple_copies_of_longer_list_different_orders` test last year ago, I ended up with a copy/paste error in the length of the `expected` list. This fixes that.