### PR TITLE
Add `mergesort.c` to files to compile in GitHub Actions

### DIFF
--- a/.github/workflows/arraymerge_gtest.yml
+++ b/.github/workflows/arraymerge_gtest.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile test code
-      run: g++ -Wall -g -o array_merge_test array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o array_merge_test ../mergesort/mergesort.c array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
       working-directory: array_merge
     - name: Run test
       run: ./array_merge_test

--- a/.github/workflows/arraymerge_test_valgrind.yml
+++ b/.github/workflows/arraymerge_test_valgrind.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v2
     - name: Compile code
-      run: g++ -Wall -g -o array_merge_test array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
+      run: g++ -Wall -g -o array_merge_test ../mergesort/mergesort.c array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
       working-directory: array_merge
     - name: Run test
       run: valgrind -v --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./array_merge_test

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Some things to watch our for:
 
 There are more comprehensive tips and suggestions in `Tips_and_suggestions.md` in the repository.
 
+:bangbang: The Array Merge problem depends on the Mergesort problem, so you really
+should do Mergesort first. The GitHub Actions (that run the tests automatically and
+create things like the status badges) actually include `mergesort.c` when they
+compile the Array Merge code, so if `mergesort.c` is incomplete or otherwise
+broken that will cause the Array Merge tests to fail.
+
 ### Mergesort
 
 Your task here is to implement a well known sorting algorithm in C,
@@ -222,7 +228,22 @@ the array without messing with that important first element.
 You can use references like `../mergesort/mergesort.h` or
 `../mergesort/mergesort.c` to access appropriate files in that part of
 the project, either in things like `#include` statements or
-in `gcc/g++` calls.
+in `gcc/g++` calls. The command in the GitHub Actions to compile
+the Array Merge tess, for example, is:
+
+```text
+g++ -Wall -g -o array_merge_test ../mergesort/mergesort.c array_merge.c array_merge_test.cpp -lgtest -pthread -std=c++0x
+```
+
+Note that the `../mergesort/mergesort.c` in this command includes
+the Mergesort `.c` file in the list of files that will be compiled
+and linked together to form the `array_merge_test` executable.
+That has two major implications:
+
+- You *must* have a working `mergesort.c` in order to get the GitHub
+  Actions for Array Merge to compile successfully.
+- You *can* (and presumably should?) use the function `mergesort()` that
+  you define in the other part of the lab here in Array Merge.
 
 ## Final Words
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ test code to handle memory leaks
 Do be careful to not remove or weaken the tests, though; at a minimum
 you definitely want to be able to pass the tests as given.
 
+:bangbang: Neither of the parts of this lab comes with a `main()` function.
+We could add one, but both of the target functions (`mergesort()` and
+`array_merge()`) are really "library" functions that don't make a
+lot of sense as functions that users would interact with directly. So
+we just have them called by the tests but don't provide a way for you
+to call them directly. If you want to create a `main.c` for either or
+both of the projects feel free to do so, but it's definitely not
+expected.
+
 ## Fixing memory problems
 
 Passing the tests is arguably just the first half of each of these problems,

--- a/array_merge/array_merge.c
+++ b/array_merge/array_merge.c
@@ -1,4 +1,5 @@
 #include "array_merge.h"
+#include "../mergesort/mergesort.h"
 
 int* array_merge(int num_arrays, int* sizes, int** values) {
   // This is obviously broken. It has the right type, though, eh?


### PR DESCRIPTION
This explicitly adds `mergesort.c` to the compile statement for `array_merge` in the GitHub Actions.

It also adds text to the README that explains why this is happening and the consequences for their work.

Closes #10 

I also added a paragraph to the `README.md` explaining why there's no `main()` in these labs. Not sure that it will help a lot, but hopefully it's an improvement.

Closes #8 